### PR TITLE
no longer use Biopython for blast; avoid deprecation

### DIFF
--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -22,7 +22,7 @@ grep MISSING reports/completeness-crawler.txt
 
 echo "Running coverage.py"
 coverage erase
-coverage run --branch -m pytest --run-raxml --run-generax --junit-xml=reports/junit/junit.xml
+coverage run --branch -m pytest --run-raxml --run-generax --run-blast --junit-xml=reports/junit/junit.xml
 
 echo "Generating reports"
 coverage html

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,11 @@ def pytest_addoption(parser):
                      action="store_true",
                      default=False,
                      help="Run tests involving raxml")
+    
+    parser.addoption("--run-blast",
+                     action="store_true",
+                     default=False,
+                     help="Run tests involving blast")
 
 def pytest_collection_modifyitems(config, items):
     """
@@ -39,6 +44,13 @@ def pytest_collection_modifyitems(config, items):
         skipper = pytest.mark.skip(reason="Only run when --run-raxml is given")
         for item in items:
             if "run_raxml" in item.keywords:
+                item.add_marker(skipper)
+
+    # Look for --run-blast argument. Skip test if this is not specified.
+    if not config.getoption("--run-blast"):
+        skipper = pytest.mark.skip(reason="Only run when --run-blast is given")
+        for item in items:
+            if "run_blast" in item.keywords:
                 item.add_marker(skipper)
 
     # If this is a windows box, skip any test with run_generax or run_raxml

--- a/tests/ncbi/blast/test_local.py
+++ b/tests/ncbi/blast/test_local.py
@@ -4,17 +4,38 @@ from conftest import get_public_param_defaults
 
 import topiary
 from topiary.ncbi.blast.local import local_blast
-from topiary.ncbi.blast.local import _prepare_for_blast as _pfb
-from topiary.ncbi.blast.local import _construct_args as _ca
+from topiary.ncbi.blast.local import _prepare_for_blast
+from topiary.ncbi.blast.local import _construct_args
 from topiary.ncbi.blast.local import _combine_hits
 from topiary.ncbi.blast.local import _local_blast_thread_function
 
-import Bio.Blast.Applications as apps
+# Functions used in testing
+from topiary.ncbi.blast.make import make_blast_db
 
 import numpy as np
 import pandas as pd
 
-import copy, os
+import copy
+import os
+import glob
+
+def _blast_args_to_keys(blast_args):
+    """
+    Take a list of args like ["blastp","-db","stupid",...] and return a 
+    dictionary where every arg is a key in a dictionary pointing to a value.
+    Assumes a single value for each key and ignores anything not starting 
+    with -. Would return {'-db':'stupid'} from above.
+    """
+    
+    out_dict = {}
+    i = 0
+    while i < len(blast_args):
+        if blast_args[i].startswith('-'):
+            out_dict[blast_args[i]] = blast_args[i+1]
+            i += 1
+        i += 1
+
+    return out_dict      
 
 def test__prepare_for_blast(test_dataframes,tmpdir):
 
@@ -24,7 +45,7 @@ def test__prepare_for_blast(test_dataframes,tmpdir):
     f.close()
     fake_blast_db = os.path.join(tmpdir,"GRCh38")
 
-    default_kwargs = get_public_param_defaults(local_blast,_pfb)
+    default_kwargs = get_public_param_defaults(local_blast,_prepare_for_blast)
     default_kwargs["db"] = fake_blast_db
     default_kwargs["test_skip_blast_program_check"] = True
     default_kwargs["kwargs"] = {}
@@ -32,23 +53,29 @@ def test__prepare_for_blast(test_dataframes,tmpdir):
     default_kwargs["sequence"] = df.sequence
 
     # Skip the check for a working blast program.
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**default_kwargs)
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**default_kwargs)
 
     # Should be a list of length 1 holding a single dictionary
     assert type(sequence_list) is list
     assert len(sequence_list) == 5
-    assert blast_function is apps.NcbiblastpCommandline
-    assert type(blast_kwargs) is dict
+    assert type(blast_args) is list
     assert return_singleton == False
 
     # Make sure it got the sequences right
     assert np.array_equal(sequence_list,df.sequence)
 
-    # Make sure the rest of the arguments were done properly
-    assert blast_kwargs["max_target_seqs"] == 100
-    assert blast_kwargs["threshold"] == 0.001
-    assert blast_kwargs["gapopen"] == 11
-    assert blast_kwargs["gapextend"] == 1
+    # Make sure the blast command is constructed correctly
+    assert blast_args[0] == "blastp"
+    assert blast_args[1] == "-db"
+    assert os.path.split(blast_args[2])[-1] == "GRCh38"
+    
+    expected = ['-outfmt', '5',
+                '-max_target_seqs','100',
+                '-threshold', '1.00000e-03',
+                '-gapopen', '11',
+                '-gapextend', '1']
+    for i in range(len(expected)):
+        assert blast_args[i+3] == expected[i]
 
     # -------------------------------------------------------------------------
     # test sequence bits
@@ -56,19 +83,19 @@ def test__prepare_for_blast(test_dataframes,tmpdir):
     kwargs = copy.deepcopy(default_kwargs)
 
     kwargs["sequence"] = "test"
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
     assert len(sequence_list) == 1
     assert sequence_list[0] == "test"
     assert return_singleton == True
 
     kwargs["sequence"] = ["test"]
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
     assert len(sequence_list) == 1
     assert sequence_list[0] == "test"
     assert return_singleton == False
 
     kwargs["sequence"] = ["test","this"]
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
     assert len(sequence_list) == 2
     assert sequence_list[0] == "test"
     assert sequence_list[1] == "this"
@@ -81,11 +108,11 @@ def test__prepare_for_blast(test_dataframes,tmpdir):
 
         kwargs["sequence"] = b
         with pytest.raises(ValueError):
-            sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
+            sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
 
         kwargs["sequence"] = [b]
         with pytest.raises(ValueError):
-            sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
+            sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
 
     # -------------------------------------------------------------------------
     # test db
@@ -94,64 +121,70 @@ def test__prepare_for_blast(test_dataframes,tmpdir):
 
     kwargs["db"] = "not_really_db"
     with pytest.raises(FileNotFoundError):
-        sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
+        sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
 
     bad_db = [1,False,1.0,-1,None,str,"",{}]
     for b in bad_db:
         print("passing bad db:",b)
         kwargs["db"] = b
         with pytest.raises(FileNotFoundError):
-            sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
+            sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
 
     # -------------------------------------------------------------------------
     # blast_program
 
     kwargs = copy.deepcopy(default_kwargs)
 
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
-    assert blast_function == apps.NcbiblastpCommandline
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+    assert blast_args[0] == "blastp"
 
     kwargs["blast_program"] = "tblastx"
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
-    assert blast_function == apps.NcbitblastxCommandline
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+    assert  blast_args[0] == "tblastx"
 
     bad_pg = ["not_really_program",1,False,1.0,-1,None,str,"",{}]
     for b in bad_pg:
         print("passing bad blast_program:",b)
         kwargs["blast_program"] = b
         with pytest.raises(ValueError):
-            sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
+            sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+
 
     # -------------------------------------------------------------------------
-    # histlist_size
+    # hitlist_size
 
     kwargs = copy.deepcopy(default_kwargs)
 
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
-    assert blast_kwargs["max_target_seqs"] == 100
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+    blast_kwargs = _blast_args_to_keys(blast_args)
 
-    kwargs["hitlist_size"] = 50
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
-    assert blast_kwargs["max_target_seqs"] == 50
+    assert blast_kwargs["-max_target_seqs"] == "100"
+
+    kwargs["hitlist_size"] = "50"
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+    blast_kwargs = _blast_args_to_keys(blast_args)
+    assert blast_kwargs["-max_target_seqs"] == "50"
 
     bad_int = [0,False,[],-1,None,str,"",{},int]
     for b in bad_int:
         print("passing bad hitlist_size:",b)
         kwargs["hitlist_size"] = b
         with pytest.raises(ValueError):
-            sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
+            sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+
 
     # -------------------------------------------------------------------------
     # evalue_cutoff
 
     kwargs = copy.deepcopy(default_kwargs)
 
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
-    assert blast_kwargs["threshold"] == 0.001
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+    assert blast_kwargs["-threshold"] == "1.00000e-03"
 
     kwargs["e_value_cutoff"] = 0.01
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
-    assert blast_kwargs["threshold"] == 0.01
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+    blast_kwargs = _blast_args_to_keys(blast_args)
+    assert blast_kwargs["-threshold"] == "1.00000e-02" 
 
     bad_float = [-1,[],None,str,"",{},int]
     for b in bad_float:
@@ -159,37 +192,38 @@ def test__prepare_for_blast(test_dataframes,tmpdir):
         kwargs["e_value_cutoff"] = b
         print("passing bad e_value_cutoff:",b)
         with pytest.raises(ValueError):
-            sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
+            sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
 
     # -------------------------------------------------------------------------
     # gapcosts
 
     kwargs = copy.deepcopy(default_kwargs)
 
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
-    assert blast_kwargs["gapopen"] == 11
-    assert blast_kwargs["gapextend"] == 1
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+    blast_kwargs = _blast_args_to_keys(blast_args)
+    assert blast_kwargs["-gapopen"] == "11"
+    assert blast_kwargs["-gapextend"] == "1"
 
     kwargs["gapcosts"] = [10,1]
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
-    assert blast_kwargs["gapopen"] == 10
-    assert blast_kwargs["gapextend"] == 1
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+    blast_kwargs = _blast_args_to_keys(blast_args)
+    assert blast_kwargs["-gapopen"] == "10"
+    assert blast_kwargs["-gapextend"] == "1"
 
     bad_gap = [-1,[],[1,2,3],[-1,1],[1,-1],["test","this"],None,str,"",{},int]
     for b in bad_gap:
         kwargs["gapcosts"] = b
         print("passing bad gapcosts:",b)
         with pytest.raises(ValueError):
-            sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
-
+            sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
 
     # -------------------------------------------------------------------------
     # Extra kwargs
     kwargs = copy.deepcopy(default_kwargs)
     kwargs["kwargs"] = {"extra_kwarg":7}
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
-    assert blast_kwargs["extra_kwarg"] == 7
-
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+    blast_kwargs = _blast_args_to_keys(blast_args)
+    assert blast_kwargs["-extra_kwarg"] == "7"
 
 def test__construct_args(test_dataframes,tmpdir):
 
@@ -200,20 +234,19 @@ def test__construct_args(test_dataframes,tmpdir):
     fake_blast_db = os.path.join(tmpdir,"GRCh38")
 
     # Create some normal looking inputs to feed into _construct_args
-    pfb_kwargs = get_public_param_defaults(local_blast,_pfb)
+    pfb_kwargs = get_public_param_defaults(local_blast,_prepare_for_blast)
     pfb_kwargs["db"] = fake_blast_db
     pfb_kwargs["test_skip_blast_program_check"] = True
     pfb_kwargs["kwargs"] = {}
     df = test_dataframes["good-df"].copy()
     pfb_kwargs["sequence"] = df.sequence
 
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**pfb_kwargs)
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**pfb_kwargs)
 
     # Run in configuration where we will have one query per core (5 threads,
     # 5 cores, 5 input sequences, long max_query_length)
-    kwargs_list, num_threads = _ca(sequence_list=sequence_list,
-                                   blast_function=blast_function,
-                                   blast_kwargs=blast_kwargs,
+    kwargs_list, num_threads = _construct_args(sequence_list=sequence_list,
+                                   blast_args=blast_args,
                                    num_threads=5,
                                    keep_blast_xml=False,
                                    block_size=1,
@@ -233,14 +266,16 @@ def test__construct_args(test_dataframes,tmpdir):
         # Make sure counter is working
         assert a["index"][0] == i
         assert a["index"][1] == i + 1
+        
 
-        assert a["blast_function"] == apps.NcbiblastpCommandline
+        blast_kwargs = _blast_args_to_keys(a["blast_args"])
 
         # useful kwargs
-        assert a["blast_kwargs"]["max_target_seqs"] == 100
-        assert a["blast_kwargs"]["threshold"] == 0.001
-        assert a["blast_kwargs"]["gapopen"] == 11
-        assert a["blast_kwargs"]["gapextend"] == 1
+        assert a["blast_args"][0] == "blastp"
+        assert blast_kwargs["-max_target_seqs"] == "100"
+        assert blast_kwargs["-threshold"] == "1.00000e-03"
+        assert blast_kwargs["-gapopen"] == "11"
+        assert blast_kwargs["-gapextend"] == "1"
 
         # Keep tmp
         assert a["keep_blast_xml"] == False
@@ -249,9 +284,8 @@ def test__construct_args(test_dataframes,tmpdir):
     # test sequence bits
 
     sequence_list = ["test"]
-    all_args, num_threads = _ca(sequence_list=sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list=sequence_list,
+                                blast_args=blast_args,
                                 num_threads=5,
                                 keep_blast_xml=False,
                                 block_size=1,
@@ -263,9 +297,8 @@ def test__construct_args(test_dataframes,tmpdir):
 
     # Machine as two core, auto detect cores. Should have two args
     sequence_list = ["test","this"]
-    all_args, num_threads = _ca(sequence_list=sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list=sequence_list,
+                                blast_args=blast_args,
                                 num_threads=5,
                                 keep_blast_xml=False,
                                 block_size=1,
@@ -278,9 +311,8 @@ def test__construct_args(test_dataframes,tmpdir):
 
     # Machine as one core, auto detect cores. Should have one arg
     sequence_list = ["test","this"]
-    all_args, num_threads = _ca(sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list,
+                                blast_args=blast_args,
                                 block_size=20,
                                 keep_blast_xml=False,
                                 num_threads=-1,
@@ -295,15 +327,14 @@ def test__construct_args(test_dataframes,tmpdir):
     # block_size
     # making sure sequence bits are processed correctly when it's included
 
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**pfb_kwargs)
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**pfb_kwargs)
 
     bad_int = [0,False,[],-1,None,str,"",{},int]
     for b in bad_int:
         print("passing bad block_size:",b)
         with pytest.raises(ValueError):
-            all_args, num_threads = _ca(sequence_list,
-                                        blast_function=blast_function,
-                                        blast_kwargs=blast_kwargs,
+            all_args, num_threads = _construct_args(sequence_list,
+                                        blast_args=blast_args,
                                         block_size=b,
                                         keep_blast_xml=False,
                                         num_threads=-1,
@@ -312,9 +343,8 @@ def test__construct_args(test_dataframes,tmpdir):
 
 
 
-    all_args, num_threads = _ca(sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list,
+                                blast_args=blast_args,
                                 block_size=5,
                                 keep_blast_xml=False,
                                 num_threads=-1,
@@ -325,9 +355,8 @@ def test__construct_args(test_dataframes,tmpdir):
     assert all_args[0]["index"][1] == 5
 
     # Make sure splitting looks reasonable -- each sequence on own
-    all_args, num_threads = _ca(sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list,
+                                blast_args=blast_args,
                                 block_size=1,
                                 keep_blast_xml=False,
                                 num_threads=-1,
@@ -340,9 +369,8 @@ def test__construct_args(test_dataframes,tmpdir):
 
 
     # Make sure splitting looks reasonable -- 2, 2, 1
-    all_args, num_threads = _ca(sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list,
+                                blast_args=blast_args,
                                 block_size=2,
                                 keep_blast_xml=False,
                                 num_threads=-1,
@@ -356,9 +384,8 @@ def test__construct_args(test_dataframes,tmpdir):
         counter += 2
 
     # Make sure splitting looks reasonable -- 3, 2
-    all_args, num_threads = _ca(sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list,
+                                blast_args=blast_args,
                                 block_size=3,
                                 keep_blast_xml=False,
                                 num_threads=-1,
@@ -372,9 +399,8 @@ def test__construct_args(test_dataframes,tmpdir):
         counter += 3
 
     # Make sure splitting looks reasonable -- 1
-    all_args, num_threads = _ca(sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list,
+                                blast_args=blast_args,
                                 block_size=5,
                                 keep_blast_xml=False,
                                 num_threads=-1,
@@ -385,18 +411,16 @@ def test__construct_args(test_dataframes,tmpdir):
     # -------------------------------------------------------------------------
     # keep_blast_xml
 
-    all_args, num_threads = _ca(sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list,
+                                blast_args=blast_args,
                                 block_size=5,
                                 keep_blast_xml=False,
                                 num_threads=3,
                                 manual_num_cores=None)
     assert all_args[0]["keep_blast_xml"] is False
 
-    all_args, num_threads = _ca(sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list,
+                                blast_args=blast_args,
                                 block_size=5,
                                 keep_blast_xml=True,
                                 num_threads=3,
@@ -408,9 +432,8 @@ def test__construct_args(test_dataframes,tmpdir):
     for b in bad_bool:
         print("passing bad keep_blast_xml:",b)
         with pytest.raises(ValueError):
-            all_args, num_threads = _ca(sequence_list,
-                                        blast_function=blast_function,
-                                        blast_kwargs=blast_kwargs,
+            all_args, num_threads = _construct_args(sequence_list,
+                                        blast_args=blast_args,
                                         block_size=5,
                                         keep_blast_xml=b,
                                         num_threads=3,
@@ -420,9 +443,8 @@ def test__construct_args(test_dataframes,tmpdir):
     # -------------------------------------------------------------------------
     # num_threads.
 
-    all_args, num_threads = _ca(sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list,
+                                blast_args=blast_args,
                                 block_size=1,
                                 keep_blast_xml=False,
                                 num_threads=3,
@@ -434,9 +456,8 @@ def test__construct_args(test_dataframes,tmpdir):
     for b in bad_int:
         print("passing bad num_threads:",b)
         with pytest.raises(ValueError):
-            all_args, num_threads = _ca(sequence_list,
-                                        blast_function=blast_function,
-                                        blast_kwargs=blast_kwargs,
+            all_args, num_threads = _construct_args(sequence_list,
+                                        blast_args=blast_args,
                                         block_size=5,
                                         keep_blast_xml=False,
                                         num_threads=b,
@@ -464,10 +485,81 @@ def test__combine_hits(local_blast_output):
     assert type(df_list) is list
     assert len(df_list) == 1
 
-def test__local_blast_thread_function():
+@pytest.mark.skipif(os.name == "nt",reason="blast cannot be installed via conda on windows")
+@pytest.mark.run_blast
+def test__local_blast_thread_function(test_dataframes,
+                                      make_blast_db_files,
+                                      tmpdir):
 
-    pass
+    # Move into temporary directory
+    cwd = os.getcwd()
+    os.chdir(tmpdir)
 
-def test_local_blast():
+    # Make a blast database
+    faa = [make_blast_db_files["test1.faa"],make_blast_db_files["test2.faa"]]
+    out = "blastdb"
+    make_blast_db(faa,db_name=out)
 
-    pass
+    pfb_kwargs = get_public_param_defaults(local_blast,_prepare_for_blast)
+    pfb_kwargs["db"] = "blastdb"
+    pfb_kwargs["test_skip_blast_program_check"] = False
+    pfb_kwargs["kwargs"] = {}
+    df = test_dataframes["good-df"].copy()
+    pfb_kwargs["sequence"] = df.sequence
+
+    sequence_list, blast_args, _ = _prepare_for_blast(**pfb_kwargs)
+
+    out_df = _local_blast_thread_function(sequence_list=sequence_list,
+                                          index=[0,len(sequence_list)],
+                                          blast_args=blast_args,
+                                          keep_blast_xml=True)
+
+    # Should be five sequences and should have created an xml file
+    assert len(out_df) == 5
+    xml_files = glob.glob("*blast-out.xml") 
+    assert len(xml_files) == 1
+    for f in xml_files:
+        os.remove(f)
+
+    # Should be two sequences, single xml file
+    out_df = _local_blast_thread_function(sequence_list=sequence_list,
+                                          index=[0,2],
+                                          blast_args=blast_args,
+                                          keep_blast_xml=True)
+    
+    assert len(out_df) == 2
+    xml_files = glob.glob("*blast-out.xml") 
+    assert len(xml_files) == 1
+    for f in xml_files:
+        os.remove(f)
+
+    os.chdir(cwd)
+
+@pytest.mark.skipif(os.name == "nt",reason="blast cannot be installed via conda on windows")
+@pytest.mark.run_blast
+def test_local_blast(test_dataframes,
+                     make_blast_db_files,
+                     tmpdir):
+
+    # This is a fairly minimal test suite because this function simply wraps and
+    # the set of local functions that are tested extensively in the rest of this
+    # test file. 
+
+    # Move into temporary directory
+    cwd = os.getcwd()
+    os.chdir(tmpdir)
+
+    # Make a blast database
+    faa = [make_blast_db_files["test1.faa"],make_blast_db_files["test2.faa"]]
+    out = "blastdb"
+    make_blast_db(faa,db_name=out)
+
+    df = test_dataframes["good-df"].copy()
+    sequence = df.sequence
+
+    query_hits = local_blast(sequence=sequence,
+                             db="blastdb")
+
+    assert len(sequence) == len(query_hits)
+
+    os.chdir(cwd)

--- a/tests/ncbi/blast/test_make.py
+++ b/tests/ncbi/blast/test_make.py
@@ -8,6 +8,7 @@ import os
 import glob
 
 @pytest.mark.skipif(os.name == "nt",reason="makeblastdb cannot be installed via conda on windows")
+@pytest.mark.run_blast
 def test_make_blast_db(make_blast_db_files,tmpdir):
 
     cwd = os.getcwd()


### PR DESCRIPTION
Switched to directly calling blast rather than using Biopython wrapper. This is because Biopython is deprecating their blast wrappers. I also added better test coverage of blast functions. 