### PR TITLE
cleaned up deprecation warnings for topiary itself

### DIFF
--- a/tests/_private/check/test_standard.py
+++ b/tests/_private/check/test_standard.py
@@ -1,6 +1,9 @@
 
 import topiary
-from topiary._private.check.standard import check_bool, check_float, check_int, check_iter
+from topiary._private.check.standard import check_bool
+from topiary._private.check.standard import check_float
+from topiary._private.check.standard import check_int
+from topiary._private.check.standard import check_iter
 from topiary._private.check.standard import column_to_bool
 
 import pytest

--- a/tests/_private/test_interface.py
+++ b/tests/_private/test_interface.py
@@ -7,6 +7,8 @@ from topiary._private.interface import create_new_dir
 from topiary._private.interface import copy_input_file
 from topiary._private.interface import run_cleanly
 from topiary._private.interface import rmtree
+from topiary._private.interface import _follow_log_generator
+from topiary._private.interface import _follow_log_subproc_wrapper
 
 import os
 import sys
@@ -132,14 +134,16 @@ def test_copy_input_file(tmpdir,test_dataframes):
 
 def test__follow_log_subproc_wrapper():
     # Super simple function that would require lots of test infrastructure to
-    # run. Return True so this is not flagged as missing by test_crawler.
-    return True
+    # run. Touch without calling to test crawler does not flag as missing
+    _follow_log_subproc_wrapper
+    return None
 
 def test__follow_log_generator():
     # Function that would require lots of test infrastructure to run. Logging
-    # not critical to results, so skipping for now. Return True so this is not
-    # flagged as missing by test_crawler.
-    return True
+    # not critical to results, so skipping for now. Touch without calling so 
+    # test crawler does not flag as missing
+    _follow_log_generator
+    return None
 
 
 def test_launch(tmpdir,programs):

--- a/tests/_private/test_threads.py
+++ b/tests/_private/test_threads.py
@@ -2,6 +2,7 @@
 import pytest
 
 from topiary._private import threads
+from topiary._private.threads import _thread
 import time, random
 
 import numpy as np
@@ -94,5 +95,7 @@ def test_thread_manager():
 
 
 def test__thread():
-    # tested implicitly in test_thread_manager.
-    return True
+    # tested implicitly in test_thread_manager. touch but do not call so test
+    # crawler does not flag as missing
+    _thread
+    return None

--- a/tests/completeness_crawler.py
+++ b/tests/completeness_crawler.py
@@ -24,12 +24,12 @@ def code_loader(filename,is_test):
     """
 
     if is_test:
-        function_finder = re.compile("def test_.*?\(.*?")
+        function_finder = re.compile("def test_.*?\\(.*?")
     else:
-        function_finder = re.compile("def .*?\(.*?")
+        function_finder = re.compile("def .*?\\(.*?")
 
     class_check = re.compile("class .*?:")
-    in_class_check = re.compile("def .*?\(self")
+    in_class_check = re.compile("def .*?\\(self")
 
     def_lines = []
     current_function = None
@@ -173,7 +173,7 @@ def completeness_crawler(code_dir,test_dir,bin_dir=None):
             if class_name is not None:
 
                 # Record as method
-                if re.search("\(self",f):
+                if re.search("\\(self",f):
                     fcn = f"{class_name}.{fcn}"
 
                 # Otherwise, not a method, we've moved out of the class

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ def get_files(base_dir):
     Traverse base_dir and return a dictionary that keys all files and some
     rudimentary *.ext expressions to absolute paths to those files. They keys
     will be things like "some_dir/test0/rocket.txt" mapping to
-    "c:\some_dir\life\base_dir\some_dir\test0\rocket.txt". The idea is to have
+    "c:/some_dir/life/base_dir/some_dir/test0/rocket.txt". The idea is to have
     easy-to-read cross-platform keys within unit tests.
 
     Classes of keys:

--- a/tests/generax/test__reconcile_no_bootstrap.py
+++ b/tests/generax/test__reconcile_no_bootstrap.py
@@ -9,7 +9,6 @@ from topiary._private import Supervisor
 import ete3
 
 import os
-import shutil
 
 @pytest.mark.run_generax
 def test_reconcile_no_bootstrap(generax_data,tmpdir):

--- a/tests/io/test_alignments.py
+++ b/tests/io/test_alignments.py
@@ -7,7 +7,8 @@ from topiary.io.alignments import _validate_seq_writer
 import numpy as np
 import pandas as pd
 
-import os, shutil, re
+import os
+import re
 
 
 def test__validate_seq_writer():
@@ -16,7 +17,10 @@ def test__validate_seq_writer():
     I'm using those unit tests because I can validate written output.
     """
 
-    return True
+    _validate_seq_writer
+    assert True
+    return None
+
 
 def test_write_fasta(test_dataframes,tmpdir):
 

--- a/tests/io/test_dataframe.py
+++ b/tests/io/test_dataframe.py
@@ -2,13 +2,10 @@ import pytest
 
 from topiary.io import read_dataframe
 from topiary.io import write_dataframe
-import numpy as np
 import pandas as pd
 
 import warnings
 import os
-import shutil
-import re
 
 def test_read_dataframe(dataframe_good_files,test_dataframes):
     """

--- a/tests/io/test_paralog_patterns.py
+++ b/tests/io/test_paralog_patterns.py
@@ -15,12 +15,12 @@ import copy
 def test__get_alias_regex():
 
     test_strings = {"ABC": "abc",
-                    "ABC1" :"abc[\ \-_\.]*1",
-                    "1ABc" :"1[\ \-_\.]*abc",
+                    "ABC1" :"abc[\\ \\-_\\.]*1",
+                    "1ABc" :"1[\\ \\-_\\.]*abc",
                     " ABC ":"abc",
-                    "AB C" :"ab[\ \-_\.]*c",
-                    "(ABC)":"\(abc\)",
-                    "[AB C]" :"\[ab[\ \-_\.]*c\]"}
+                    "AB C" :"ab[\\ \\-_\\.]*c",
+                    "(ABC)":"\\(abc\\)",
+                    "[AB C]" :"\\[ab[\\ \\-_\\.]*c\\]"}
     spacers = [" ","-","_","."]
     for t in test_strings:
         assert _get_alias_regex(t,spacers) == test_strings[t]
@@ -37,9 +37,9 @@ def test__get_alias_regex():
 
     test_strings = {"A" :"a",
                     "1" :"1",
-                    "1A":"1[\ \-_\.]*a",
-                    "A1":"a[\ \-_\.]*1",
-                    " A1 " :"a[\ \-_\.]*1"}
+                    "1A":"1[\\ \\-_\\.]*a",
+                    "A1":"a[\\ \\-_\\.]*1",
+                    " A1 " :"a[\\ \\-_\\.]*1"}
     spacers = [" ","-","_","."]
     for t in test_strings:
         assert _get_alias_regex(t,spacers) == test_strings[t]

--- a/tests/io/test_seed.py
+++ b/tests/io/test_seed.py
@@ -49,8 +49,8 @@ def test_read_seed(seed_dataframes,user_seed_dataframes):
 
         # Test paralog patterns
         expected_patterns = {
-            "LY96":"esop[\ \-_\.]*1|ly[\ \-_\.]*96|lymphocyte[\ \-_\.]*antigen[\ \-_\.]*96|myeloid[\ \-_\.]*differentiation[\ \-_\.]*protein[\ \-_\.]*2",
-            "LY86":"ly[\ \-_\.]*86|lymphocyte[\ \-_\.]*antigen[\ \-_\.]*86|md[\ \-_\.]*1|mmd[\ \-_\.]*1|rp[\ \-_\.]*105[\ \-_\.]*associated[\ \-_\.]*3"
+            "LY96":"esop[\\ \\-_\\.]*1|ly[\\ \\-_\\.]*96|lymphocyte[\\ \\-_\\.]*antigen[\\ \\-_\\.]*96|myeloid[\\ \\-_\\.]*differentiation[\\ \\-_\\.]*protein[\\ \\-_\\.]*2",
+            "LY86":"ly[\\ \\-_\\.]*86|lymphocyte[\\ \\-_\\.]*antigen[\\ \\-_\\.]*86|md[\\ \\-_\\.]*1|mmd[\\ \\-_\\.]*1|rp[\\ \\-_\\.]*105[\\ \\-_\\.]*associated[\\ \\-_\\.]*3"
         }
         for k in paralog_patterns:
             print(paralog_patterns[k].pattern)

--- a/tests/ncbi/test__parse_ncbi_line.py
+++ b/tests/ncbi/test__parse_ncbi_line.py
@@ -4,14 +4,17 @@ import pytest
 import topiary
 import copy
 
-from topiary.ncbi._parse_ncbi_line import parse_ncbi_line, _grab_line_meta_data
+from topiary.ncbi._parse_ncbi_line import _grab_line_meta_data
+from topiary.ncbi._parse_ncbi_line import parse_ncbi_line
 
 def test__grab_line_meta_data(ncbi_lines):
 
     # This function is implicitly and rigorously tested by test_parse_ncbi_line.
     # I'd have to make separate test data manually, so I'll rely on
-    # test_parse_ncbi_line.
-    return True
+    # test_parse_ncbi_line. Touch function but do not call so this is not 
+    # flagged as missing by test crawler
+    _grab_line_meta_data
+    return None
 
 
 def test_parse_ncbi_line(ncbi_lines):

--- a/tests/util/test_create_nicknames.py
+++ b/tests/util/test_create_nicknames.py
@@ -92,7 +92,7 @@ def test_create_nicknames(test_dataframes):
     # Do again, but do some stuff that requires escape characters and more
     # interesting regular expressions
     test_df = df.copy()
-    test_df.loc[:,"name"] = ["|rocking","rock","\in","the","usa"]
+    test_df.loc[:,"name"] = ["|rocking","rock","\\in","the","usa"]
     paralog_patterns = {"fixed":("|rock","out"),
                         "junk":(re.compile("the|us."))}
     out_df = util.create_nicknames(test_df,output_column="test1",paralog_patterns=paralog_patterns)

--- a/topiary/_private/check/topiary_dataframe.py
+++ b/topiary/_private/check/topiary_dataframe.py
@@ -162,11 +162,14 @@ def check_topiary_dataframe(df):
 
     if keep is not None:
 
-        # Validate this as a boolean column
-        df.loc[:,"keep"] = column_to_bool(df.loc[:,"keep"],"keep")
+        # Validate this as a boolean column, casting if needed
+        column_as_bool = column_to_bool(df.loc[:,"keep"],"keep")
 
         # Force it to really be bool
         df = df.astype({"keep":bool})
+
+        # Assign our converted values
+        df.loc[:,"keep"] = column_as_bool
 
     # -------------------------------------------------------------------------
     # Process uid column

--- a/topiary/_private/wrap.py
+++ b/topiary/_private/wrap.py
@@ -48,7 +48,7 @@ class IterFromFile(argparse.Action):
                         final_values.append(self._value_type(v))
                     except (TypeError,ValueError):
 
-                        err = f"\n\Reading '{option_string} {values[0]}' as a file.\n"
+                        err = f"\nReading '{option_string} {values[0]}' as a file.\n"
                         err += f"Could not parse line '{v}' as '{type_name}'. {option_string} should\n"
                         err += f"either have a single argument that points to a file with one '{type_name}'\n"
                         err += f"on each line or have one or more arguments that can be interpreted as\n"

--- a/topiary/io/paralog_patterns.py
+++ b/topiary/io/paralog_patterns.py
@@ -34,10 +34,10 @@ def _get_alias_regex(some_string,
     expressions to match those patterns. 
 
     Examples (for spacers = [" ","-","_","."]):
-        "LY96" -> "ly[\ \-_\.]*96"
-        "MD-2" -> "md[\ \-_\.]*2"
-        "myeloid factor 2" -> "myeloid[\ \-_\.]*factor[\ \-_\.]*2"
-        "CDR2L" -> "cdr[\ \-_\.]*2[\ \-_\.]*L"
+        "LY96" -> "ly[\\ \\-_\\.]*96"
+        "MD-2" -> "md[\\ \\-_\\.]*2"
+        "myeloid factor 2" -> "myeloid[\\ \\-_\\.]*factor[\\ \\-_\\.]*2"
+        "CDR2L" -> "cdr[\\ \\-_\\.]*2[\\ \\-_\\.]*L"
 
     Parameters
     ----------

--- a/topiary/ncbi/_parse_ncbi_line.py
+++ b/topiary/ncbi/_parse_ncbi_line.py
@@ -152,16 +152,16 @@ def parse_ncbi_line(line,accession=None):
 
     # Start with [[genus] species]
     sm = None
-    species_pattern = re.compile("\[.*?\[.*?].*?]")
+    species_pattern = re.compile("\\[.*?\\[.*?].*?]")
     for sm in species_pattern.finditer(line):
         pass
     if sm:
         species = sm.group(0)[1:-1]
-        species = re.sub("[\[\]]","",species)
+        species = re.sub("[\\[\\]]","",species)
 
     # If we didn't get species yet, look for [something this]
     if species is None:
-        species_pattern = re.compile("\[.*?\]")
+        species_pattern = re.compile("\\[.*?\\]")
         sm = None
         for sm in species_pattern.finditer(line):
             pass

--- a/topiary/ncbi/blast/make.py
+++ b/topiary/ncbi/blast/make.py
@@ -62,7 +62,7 @@ def make_blast_db(input_files,db_name,overwrite=False,makeblastdb_binary="makebl
     try:
         subprocess.run([makeblastdb_binary],capture_output=True)
     except FileNotFoundError:
-        err = f"\makeblastdb_binary binary '{makeblastdb_binary}' not found in path\n\n"
+        err = f"makeblastdb_binary binary '{makeblastdb_binary}' not found in path\n\n"
         raise ValueError(err)
 
     rand_string = "".join([random.choice(string.ascii_letters) for _ in range(10)])

--- a/topiary/ncbi/blast/read.py
+++ b/topiary/ncbi/blast/read.py
@@ -113,58 +113,60 @@ def records_to_df(blast_records):
         pandas dataframe with all blast hits
     """
 
+    column_stereotype = {'accession': str,
+                         'hit_def': str,
+                         'hit_id': str,
+                         'title': str,
+                         'length': int,
+                         'e_value': float,
+                         'bits': float,
+                         'sequence': str,
+                         'subject_start': int,
+                         'subject_end':int,
+                         'query_start':int,
+                         'query_end':int,
+                         'query':str}
+
     out_df = []
     for record in blast_records:
 
-        # Prepare DataFrame fields.
-        data = {'accession': [],
-                'hit_def': [],
-                'hit_id': [],
-                'title': [],
-                'length': [],
-                'e_value': [],
-                'bits': [],
-                'sequence': [],
-                'subject_start': [],
-                'subject_end':[],
-                'query_start':[],
-                'query_end':[],
-                'query':[]}
-
+        # Make dictionary of empty lists to populate with datatypes
+        data = dict([(c,[]) for c in column_stereotype])
+        
         # Get alignments from blast result.
-        for i, s in enumerate(record.alignments):
+        if len(record.alignments) > 0:
 
-            data['accession'].append(s.accession)
-            data['hit_def'].append(s.hit_def)
-            data['hit_id'].append(s.hit_id)
-            data['title'].append(s.title)
-            data['length'].append(s.length)
-            data['e_value'].append(s.hsps[0].expect)
-            data['bits'].append(s.hsps[0].bits)
-            data['sequence'].append(s.hsps[0].sbjct)
-            data['subject_start'].append(s.hsps[0].sbjct_start)
-            data['subject_end'].append(s.hsps[0].sbjct_end)
-            data['query_start'].append(s.hsps[0].query_start)
-            data['query_end'].append(s.hsps[0].query_end)
-            data['query'].append(record.query)
+            for s in record.alignments:
 
-        if len(record.alignments) == 0:
-            data['accession'].append(pd.NA)
-            data['hit_def'].append(pd.NA)
-            data['hit_id'].append(pd.NA)
-            data['title'].append(pd.NA)
-            data['length'].append(pd.NA)
-            data['e_value'].append(pd.NA)
-            data['bits'].append(pd.NA)
-            data['sequence'].append(pd.NA)
-            data['subject_start'].append(pd.NA)
-            data['subject_end'].append(pd.NA)
-            data['query_start'].append(pd.NA)
-            data['query_end'].append(pd.NA)
-            data['query'].append(record.query)
+                data['accession'].append(s.accession)
+                data['hit_def'].append(s.hit_def)
+                data['hit_id'].append(s.hit_id)
+                data['title'].append(s.title)
+                data['length'].append(int(s.length))
+                data['e_value'].append(float(s.hsps[0].expect))
+                data['bits'].append(float(s.hsps[0].bits))
+                data['sequence'].append(s.hsps[0].sbjct)
+                data['subject_start'].append(int(s.hsps[0].sbjct_start))
+                data['subject_end'].append(int(s.hsps[0].sbjct_end))
+                data['query_start'].append(int(s.hsps[0].query_start))
+                data['query_end'].append(int(s.hsps[0].query_end))
+                data['query'].append(record.query)
 
-        # Port to DataFrame.
-        out_df.append(pd.DataFrame(data))
+                this_df = pd.DataFrame(data)
+
+        else:
+
+            # Build an empty dataframe with defined column types
+            this_df = pd.DataFrame(data)
+            this_df = this_df.astype(column_stereotype)
+            dummy_row = [pd.NA,pd.NA,pd.NA,pd.NA,
+                         pd.NA,np.nan,np.nan,pd.NA,
+                         pd.NA,pd.NA,pd.NA,pd.NA,
+                         record.query]
+            this_df.loc[0,:] = dummy_row
+                         
+        # Append newly constructed dataframe
+        out_df.append(this_df)
 
     out_df = pd.concat(out_df,ignore_index=True)
 

--- a/topiary/ncbi/blast/recip.py
+++ b/topiary/ncbi/blast/recip.py
@@ -608,7 +608,7 @@ def recip_blast(df,
        LY96; hits with 'lymphocyte antigen 86' or 'MD-1' will map to LY86. Hits
        that match neither would not be assigned a paralog. String patterns are
        interpreted literally. The pattern :code:`"[A-Z]"` would be escaped to
-       look for :code:`"\[A\-Z\]"`. If you want to use regular expressions in
+       look for :code:`"\\[A\\-Z\\]"`. If you want to use regular expressions in
        your patterns, pass them in as compiled regular expressions. For example,
 
        .. code-block:: python

--- a/topiary/util/create_nicknames.py
+++ b/topiary/util/create_nicknames.py
@@ -83,6 +83,11 @@ def create_nicknames(df,
             err = f"\ndataframe already has output_column '{output_column}'.\n"
             err += "To overwrite set overwrite_output = True\n\n"
             raise ValueError(err)
+        
+        # Drop existing column if we are overwriting in case it has a different
+        # type from the incoming type (str)
+        df = df.drop(columns=[output_column])
+
     except KeyError:
         pass
 


### PR DESCRIPTION
Cleaned up warnings. This included:

+ A couple of pandas DataFrame warnings regarding type casting. I am now more explicit in column type selection for blast data frames. 
+ Regex escape string warnings raised by flake8. 
+ pytest warnings for test functions returning values rather than None. 

I also deleted unused imports and split a few single-line, multi-module imports into multiple lines. 